### PR TITLE
#FEAT | Get all stores

### DIFF
--- a/src/modules/stores/controllers/store.controller.ts
+++ b/src/modules/stores/controllers/store.controller.ts
@@ -1,7 +1,6 @@
 import { Body, Controller, Get, Post, Query, Request } from "@nestjs/common";
 import { CreateStoreDto } from "../dto/create-store.dto";
 import { StoreService } from "../services/store.service";
-import { plainToInstance } from "class-transformer";
 
 @Controller('api/v1/store')
 export class StoreController {
@@ -10,12 +9,11 @@ export class StoreController {
   @Post()
   async createStore(@Body() createStoreDto: CreateStoreDto, @Request() req) {
     const store = await this.storeService.createStore(createStoreDto, req);
-    const transformedStore = plainToInstance(CreateStoreDto, store, { excludeExtraneousValues: true });
 
     return {
       statusCode: 201,
       message: 'Store created successfully',
-      data: transformedStore
+      data: store
     }
   }
 

--- a/src/modules/stores/controllers/store.controller.ts
+++ b/src/modules/stores/controllers/store.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Request } from "@nestjs/common";
+import { Body, Controller, Get, Post, Query, Request } from "@nestjs/common";
 import { CreateStoreDto } from "../dto/create-store.dto";
 import { StoreService } from "../services/store.service";
 import { plainToInstance } from "class-transformer";
@@ -20,15 +20,18 @@ export class StoreController {
   }
 
   @Get()
-  async getStores(@Request() req) {
-    const stores = await this.storeService.getAllStores(req);
-    const transformedStores = plainToInstance(CreateStoreDto, stores, { excludeExtraneousValues: true });
+  async getAllStores(@Query('limit') limit: number = 10, @Query('offset') offset: number = 0, @Request() req, ) {
+    const { stores, total } = await this.storeService.getAllStores(limit, offset, req);
 
     return {
       statusCode: 200,
       message: 'Stores fetched successfully',
-      count: stores.length,
-      data: transformedStores
+      data: {
+        stores,
+        limit,
+        offset, 
+        total
+      }
     }
   }
 }

--- a/src/modules/stores/controllers/store.controller.ts
+++ b/src/modules/stores/controllers/store.controller.ts
@@ -1,7 +1,7 @@
-import { Body, Controller, Post, Request } from "@nestjs/common";
+import { Body, Controller, Get, Post, Request } from "@nestjs/common";
 import { CreateStoreDto } from "../dto/create-store.dto";
 import { StoreService } from "../services/store.service";
-import { plainToClass } from "class-transformer";
+import { plainToInstance } from "class-transformer";
 
 @Controller('api/v1/store')
 export class StoreController {
@@ -10,12 +10,25 @@ export class StoreController {
   @Post()
   async createStore(@Body() createStoreDto: CreateStoreDto, @Request() req) {
     const store = await this.storeService.createStore(createStoreDto, req);
-    const transformedStore = plainToClass(CreateStoreDto, store, { excludeExtraneousValues: true });
+    const transformedStore = plainToInstance(CreateStoreDto, store, { excludeExtraneousValues: true });
 
     return {
       statusCode: 201,
       message: 'Store created successfully',
       data: transformedStore
+    }
+  }
+
+  @Get()
+  async getStores(@Request() req) {
+    const stores = await this.storeService.getAllStores(req);
+    const transformedStores = plainToInstance(CreateStoreDto, stores, { excludeExtraneousValues: true });
+
+    return {
+      statusCode: 200,
+      message: 'Stores fetched successfully',
+      count: stores.length,
+      data: transformedStores
     }
   }
 }

--- a/src/modules/stores/services/store.service.ts
+++ b/src/modules/stores/services/store.service.ts
@@ -14,7 +14,7 @@ export class StoreService {
     private readonly logger: LoggerService,
   ) {}
 
-  async createStore(createStoreDto: CreateStoreDto, req: Request): Promise<Store> {
+  async createStore(createStoreDto: CreateStoreDto, req: Request): Promise<CreateStoreDto> {
     const correlationId = req['correlationId'];
 
     this.logger.log('Creating new store.', correlationId);
@@ -22,9 +22,11 @@ export class StoreService {
     try {
       const newStore = new this.storeModel(createStoreDto);
       await newStore.save();
+
+      const transformedStore = plainToInstance(CreateStoreDto, newStore.toObject(), { excludeExtraneousValues: true });
       
       this.logger.log('Store created successfully!', correlationId);
-      return newStore;
+      return transformedStore;
 
     } catch (error) {
       this.logger.error('Error creating store.', error.stack, correlationId);

--- a/src/modules/stores/services/store.service.ts
+++ b/src/modules/stores/services/store.service.ts
@@ -31,7 +31,7 @@ export class StoreService {
     }
   }
 
-  async getStores(req: Request): Promise<Store[]> {
+  async getAllStores(req: Request): Promise<Store[]> {
     const correlationId = req['correlationId'];
 
     this.logger.log('Fetching all stores.', correlationId);

--- a/src/modules/stores/services/store.service.ts
+++ b/src/modules/stores/services/store.service.ts
@@ -24,8 +24,26 @@ export class StoreService {
       
       this.logger.log('Store created successfully!', correlationId);
       return newStore;
+
     } catch (error) {
       this.logger.error('Error creating store.', error.stack, correlationId);
+      throw error;
+    }
+  }
+
+  async getStores(req: Request): Promise<Store[]> {
+    const correlationId = req['correlationId'];
+
+    this.logger.log('Fetching all stores.', correlationId);
+
+    try {
+      const stores = await this.storeModel.find().exec();
+
+      this.logger.log('Stores fetched successfully!', correlationId);
+      return stores;
+
+    } catch (error) {
+      this.logger.error('Error fetching stores.', error.stack, correlationId);
       throw error;
     }
   }


### PR DESCRIPTION
### Description:
Implemented functionality to fetch all stores with pagination

### Tasks done:
- Created a service to fetch all stores 
- Create a controller endpoint to handle the GET request to fetch all stores
- Added limit, offset and total to the response of the endpoint
- Moved the logic for transforming store documents of the Create Store into the service layer

### New API endpoint:
Method: GET
Route: api/v1/store

### Request body:
No request body required for this endpoint.

### Request Parameters:
- limit (optional) - maximum number of stores to return (default is 10)
- offset (optional) - number of stores to skip (default is 0)

Example: api/v1/store?limit=10&offset=0

### Response Structure
```json
{
  "statusCode": 200,
  "message": "Stores fetched successfully",
  "count": 10,
  "data": [
    {
      "storeName": "Loja Do Norte",
      "takeOutInStore": false,
      "shippingTimeInDays": 2,
      "type": "LOJA",
      "telephoneNumber": "1234525423",
      "emailAddress": "loja@central.com",
      "address": {
        "address1": "Rua Meio, 2200",
        "neighborhood": "Centro",
        "city": "São Paulo",
        "state": "SP",
        "country": "Brasil",
        "postalCode": "12445-672",
        "latitude": -23.55052,
        "longitude": -46.6333
      }
    }
  ]
}
```
